### PR TITLE
Fix errors for python3.13 (it's HA 2025.1 ready too)

### DIFF
--- a/custom_components/invoxia/coordinator.py
+++ b/custom_components/invoxia/coordinator.py
@@ -7,7 +7,9 @@ from async_timeout import timeout
 from gps_tracker import AsyncClient, Tracker
 from gps_tracker.client.exceptions import GpsTrackerException
 
+from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import UNDEFINED
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DATA_UPDATE_INTERVAL, DOMAIN, LOGGER
@@ -18,17 +20,26 @@ class GpsTrackerCoordinator(DataUpdateCoordinator):
     """Coordinator to update GpsTracker entities."""
 
     def __init__(
-        self, hass: HomeAssistant, client: AsyncClient, tracker: Tracker
+        self, hass: HomeAssistant, config_entry: config_entries.ConfigEntry, client: AsyncClient, tracker: Tracker
     ) -> None:
         """Coordinator for single tracker."""
+        self._client = client
+        self._tracker = tracker
+        if config_entry is UNDEFINED:
+            self.config_entry = config_entries.current_entry.get()
+            # This should be deprecated once all core integrations are updated
+            # to pass in the config entry explicitly.
+        else:
+            self.config_entry = config_entry
+
+        if self.config_entry:
+            self.config_entry.async_on_unload(self.async_shutdown)
         super().__init__(
             hass,
             LOGGER,
             name=DOMAIN,
             update_interval=DATA_UPDATE_INTERVAL,
         )
-        self._client = client
-        self._tracker = tracker
 
     async def _async_update_data(self) -> GpsTrackerData:
         """Fetch data from API."""


### PR DESCRIPTION
Hi. I had 2 errors and this component couldn't work anymore without these changes.


```
2024-12-25 09:10:53.077 ERROR (MainThread) [homeassistant.components.device_tracker] Error while setting up invoxia platform for device_tracker
Traceback (most recent call last):
  File "/Users/foo/homeassistant/lib/python3.13/site-packages/homeassistant/helpers/frame.py", line 208, in report_usage
    integration_frame = get_integration_frame(
        exclude_integrations=exclude_integrations
    )
  File "/Users/foo/homeassistant/lib/python3.13/site-packages/homeassistant/helpers/frame.py", line 113, in get_integration_frame
    raise MissingIntegrationFrame
homeassistant.helpers.frame.MissingIntegrationFrame

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/foo/homeassistant/lib/python3.13/site-packages/homeassistant/helpers/entity_platform.py", line 366, in _async_setup_platform
    await asyncio.shield(awaitable)
  File "/Users/foo/.homeassistant/custom_components/invoxia/device_tracker.py", line 37, in async_setup_entry
    await asyncio.gather(
    ...<4 lines>...
    )
  File "/Users/foo/homeassistant/lib/python3.13/site-packages/homeassistant/helpers/update_coordinator.py", line 299, in async_config_entry_first_refresh
    report_usage(
    ~~~~~~~~~~~~^
        "uses `async_config_entry_first_refresh`, which is only supported "
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
        breaks_in_ha_version="2025.11",
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/foo/homeassistant/lib/python3.13/site-packages/homeassistant/helpers/frame.py", line 227, in report_usage
    raise RuntimeError(msg) from err
```
 And:

```
2024-12-26 12:15:54.165 ERROR (MainThread) [homeassistant.components.device_tracker] Error while setting up invoxia platform for device_tracker
Traceback (most recent call last):
  File "/Users/foo/homeassistant/lib/python3.13/site-packages/homeassistant/helpers/entity_platform.py", line 366, in _async_setup_platform
    await asyncio.shield(awaitable)
  File "/Users/foo/.homeassistant/custom_components/invoxia/device_tracker.py", line 34, in async_setup_entry
    GpsTrackerCoordinator(hass, client, tracker) for tracker in trackers
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
TypeError: GpsTrackerCoordinator.__init__() missing 1 required positional argument: 'tracker'
```
